### PR TITLE
Bug Fix <Message=Table DOL.Database.Race is not registered for Database Connection>

### DIFF
--- a/MannikToolbox/Forms/MainForm.cs
+++ b/MannikToolbox/Forms/MainForm.cs
@@ -44,7 +44,9 @@ namespace MannikToolbox.Forms
 		    }
 
             var loading = new LoadingForm();
-            loading.Show();
+			//prevent clicking behind berfore connections made : Loki
+			ToolboxTabControl.Enabled = false;
+			loading.Show();
 		    var progress = new Progress<int>(percent =>
 		    {
 		        loading.ProgressBar.Value = percent;
@@ -59,7 +61,8 @@ namespace MannikToolbox.Forms
 
 		        if (percent == 100)
 		        {
-		            loading.Close();
+					ToolboxTabControl.Enabled = true;
+					loading.Close();
 		        }
 		    });
 


### PR DESCRIPTION
Disable ToolboxTabControl on loading to prevent clicking tabs before DBTables are registered throwing "Message=Table DOL.Database.Race is not registered for Database Connection..."