### PR TITLE
Make BindingService.Sync more forgiving to missing values

### DIFF
--- a/MannikToolbox/Controls/ItemTemplateControl.cs
+++ b/MannikToolbox/Controls/ItemTemplateControl.cs
@@ -5,7 +5,6 @@ using System.Windows.Forms;
 using DOL.Database;
 using MannikToolbox.Forms;
 using MannikToolbox.Services;
-using System.Threading.Tasks;
 
 namespace MannikToolbox.Controls
 {
@@ -61,29 +60,6 @@ namespace MannikToolbox.Controls
 
             BindingService.BindData(_item, this);
 
-        }
-
-        private void _Model_Leave(object sender, EventArgs e)
-        {
-            pictureBox1.Image = null;
-
-            if (int.TryParse(_Model.Text, out var modelId))
-            {
-                _modelImageService.LoadItem(modelId, pictureBox1.Width, pictureBox1.Height)
-                    .ContinueWith(x => pictureBox1.Image = x.Result);
-            }
-        }
-
-        private void itemSearch_Click(object sender, EventArgs e)
-        {
-            var itemsearch = new MobSearch();
-
-            itemsearch.SelectNpcClicked += (o, args) =>
-            {
-                LoadItem(o.ToString());
-            };
-
-            itemsearch.ShowDialog(this);
         }
 
         private void SetupDropdowns()

--- a/MannikToolbox/Services/BindingService.cs
+++ b/MannikToolbox/Services/BindingService.cs
@@ -111,14 +111,9 @@ namespace MannikToolbox.Services
 
         private static void BindValueFromCombobox<T>(ComboboxService.SelectItemModel input, PropertyInfo property, T obj)
         {
-            if (input?.Id == null && Nullable.GetUnderlyingType(property.PropertyType) == null)
+            if (input?.Id == null)
             {
-                property.SetValue(obj, default(int));
-                return;
-            }
-            if(input?.Id == null)
-            {
-                property.SetValue(obj, null);
+                property.SetValue(obj, GetDefault(property.PropertyType));
                 return;
             }
 
@@ -157,6 +152,12 @@ namespace MannikToolbox.Services
         private static void BindValueFromString<T>(string input, PropertyInfo property, T obj)
         {
             var propertyType = property.PropertyType;
+
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                property.SetValue(obj, GetDefault(property.PropertyType));
+                return;
+            }
 
             if (propertyType == typeof(string))
             {
@@ -245,6 +246,18 @@ namespace MannikToolbox.Services
             else
             {
                 throw new ApplicationException($"Unsupported binding type {propertyType.Name}");
+            }
+        }
+
+        private static object GetDefault(Type type)
+        {
+            try
+            {
+                return Activator.CreateInstance(type);
+            }
+            catch (MissingMethodException)
+            {
+                return null;
             }
         }
     }


### PR DESCRIPTION
When source data is null BindingService will use default value for that data type instead. This does not replace model validation which does not yet exist on any tab, it just makes the binding more forgiving.