### PR TITLE
Item Tab Fixes

### DIFF
--- a/DOLToolbox/Controls/ItemTemplateControl.cs
+++ b/DOLToolbox/Controls/ItemTemplateControl.cs
@@ -41,6 +41,8 @@ namespace DOLToolbox.Controls
 
         private void LoadItem(string itemId)
         {
+            Clear();
+
             if (string.IsNullOrWhiteSpace(itemId))
             {
                 return;
@@ -104,34 +106,34 @@ namespace DOLToolbox.Controls
 
             switch (category.SelectedIndex)
             {
-                case 1:
+                case 0:
                     ComboboxService.BindBonusAll(type);
                     break;
-                case 2:
+                case 1:
                     ComboboxService.BindBonusStats(type);
                     break;
-                case 3:
+                case 2:
                     ComboboxService.BindBonusStatCap(type);
                     break;
-                case 4:
+                case 3:
                     ComboboxService.BindBonusResists(type);
                     break;
-                case 5:
+                case 4:
                     ComboboxService.BindBonusResistCap(type);
                     break;
-                case 6:
+                case 5:
                     ComboboxService.BindBonusSkills(type);
                     break;
-                case 7:
+                case 6:
                     ComboboxService.BindBonusFocus(type);
                     break;
-                case 8:
+                case 7:
                     ComboboxService.BindBonusToa(type);
                     break;
-                case 9:
+                case 8:
                     ComboboxService.BindBonusOther(type);
                     break;
-                case 10:
+                case 9:
                     ComboboxService.BindBonusMythical(type);
                     break;
             }

--- a/DOLToolbox/Services/ComboboxService.cs
+++ b/DOLToolbox/Services/ComboboxService.cs
@@ -483,10 +483,10 @@ namespace DOLToolbox.Services
             BindData(input, items);
         }
 
-        private static void BindData(ComboBox input, List<SelectItemModel> data)
+        private static void BindData(ComboBox input, List<SelectItemModel> data, string nullLabel = "Undefined")
         {
             if (data.All(x => x.Id != null))
-                data.Insert(0, new SelectItemModel(null, "Undefined"));
+                data.Insert(0, new SelectItemModel(null, nullLabel));
 
             input.DataSource = new BindingSource(data, null);
             input.DisplayMember = "Value";
@@ -789,19 +789,18 @@ namespace DOLToolbox.Services
         {
             var items = new List<SelectItemModel>
             {
-                new SelectItemModel(1, "All"),
-                new SelectItemModel(2, "Stats"),
-                new SelectItemModel(3, "Stat Cap"),
-                new SelectItemModel(4, "Resists"),
-                new SelectItemModel(5, "Resist Cap"),
-                new SelectItemModel(6, "Skills"),
-                new SelectItemModel(7, "Focus"),
-                new SelectItemModel(8, "Trials of Atlantis"),
-                new SelectItemModel(9, "Other"),
-                new SelectItemModel(10, "Mythical")
+                new SelectItemModel(1, "Stats"),
+                new SelectItemModel(2, "Stat Cap"),
+                new SelectItemModel(3, "Resists"),
+                new SelectItemModel(4, "Resist Cap"),
+                new SelectItemModel(5, "Skills"),
+                new SelectItemModel(6, "Focus"),
+                new SelectItemModel(7, "Trials of Atlantis"),
+                new SelectItemModel(8, "Other"),
+                new SelectItemModel(9, "Mythical")
             };
 
-            BindData(input, items);
+            BindData(input, items, "All");
         }
 
         public static void BindItemExtension(ComboBox input)


### PR DESCRIPTION
Make is so item bonuses load property on item selection.
Clear before loading item to prevent previously loaded item artifacts