### PR TITLE
Save on refresh

### DIFF
--- a/DOLToolbox/Controls/ItemTemplateControl.cs
+++ b/DOLToolbox/Controls/ItemTemplateControl.cs
@@ -224,10 +224,7 @@ namespace DOLToolbox.Controls
         {
             if (_item == null)
             {
-                _item = new ItemTemplate
-                {
-                    ObjectId = null
-                };
+                _item = new ItemTemplate();
             }
 
             try
@@ -239,7 +236,9 @@ namespace DOLToolbox.Controls
                 MessageBox.Show(ex.Message);
                 return;
             }
-            _itemService.SaveItem(_item);
+
+            var itemId = _itemService.SaveItem(_item);
+            LoadItem(itemId);
         }
 
         private void button1_Click(object sender, EventArgs e)

--- a/DOLToolbox/Controls/MobControl.cs
+++ b/DOLToolbox/Controls/MobControl.cs
@@ -49,8 +49,11 @@ namespace DOLToolbox.Controls
         private void LoadMob(string mobId)
         {
             if (string.IsNullOrWhiteSpace(mobId))
+            {
                 return;
+            }
 
+            ClearMob();
             _mob = _mobService.GetMob(mobId);
 
             if (_mob == null)
@@ -71,10 +74,7 @@ namespace DOLToolbox.Controls
         {
             if (_mob == null)
             {
-                _mob = new Mob
-                {
-                    ObjectId = null
-                };
+                _mob = new Mob();
             }
 
             try
@@ -89,8 +89,9 @@ namespace DOLToolbox.Controls
 
             SyncFlags();
             SyncWeaponSlots();
-            _mobService.SaveMob(_mob);
-            BindingService.ClearData(this);
+
+            var mobId = _mobService.SaveMob(_mob);
+            LoadMob(mobId);
         }
 
         private void _Model_Leave(object sender, EventArgs e)

--- a/DOLToolbox/Controls/NpcTemplateControl.cs
+++ b/DOLToolbox/Controls/NpcTemplateControl.cs
@@ -157,6 +157,8 @@ namespace DOLToolbox.Controls
                 return;
             }
 
+            Clear();
+
             BindingService.BindData(_template, this);
             BindFlags();
             BindWeaponSlots();
@@ -186,8 +188,9 @@ namespace DOLToolbox.Controls
             BindingService.SyncData(_template, this);
             SyncFlags();
             SyncWeaponSlots();
-            _npcTemplateService.Save(_template);
-            BindingService.ClearData(this);
+
+            var templateId = _npcTemplateService.Save(_template);
+            LoadItem(templateId);
         }
 
         private void _Race_SelectedIndexChanged(object sender, System.EventArgs e)
@@ -212,8 +215,9 @@ namespace DOLToolbox.Controls
             SyncWeaponSlots();
 
             _template.ObjectId = null;
-            _npcTemplateService.Save(_template);
-            BindingService.ClearData(this);
+
+            var templateId = _npcTemplateService.Save(_template);
+            LoadItem(templateId);
         }
 
         private void button3_Click(object sender, System.EventArgs e)

--- a/DOLToolbox/Controls/SpellControl.cs
+++ b/DOLToolbox/Controls/SpellControl.cs
@@ -50,7 +50,7 @@ namespace DOLToolbox.Controls
             ComboboxService.BindInstrumentRequirements(_InstrumentRequirement);
         }
 
-        private void Insertspell_Click(object sender, EventArgs e)
+        private async void Insertspell_Click(object sender, EventArgs e)
         {
             _spell = new DBSpell
             {
@@ -58,12 +58,11 @@ namespace DOLToolbox.Controls
             };
 
             SyncSpell();
-
-            _spell.ObjectId = null;
+            
             _spell.SpellID = _spellService.GetNextSpellId();
-
-            _spellService.Save(_spell);
-            BindingService.ClearData(this);
+            
+            var spellId = _spellService.Save(_spell);
+            await LoadSpell(spellId);
         }
 
         private async void button1_Click(object sender, EventArgs e)
@@ -80,7 +79,7 @@ namespace DOLToolbox.Controls
             dialog.Dispose();
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        private async void button2_Click(object sender, EventArgs e)
         {
             if (_spell == null)
             {
@@ -88,8 +87,9 @@ namespace DOLToolbox.Controls
             }
 
             SyncSpell();
-            _spellService.Save(_spell);
-            Clear();
+
+            var spellId = _spellService.Save(_spell);
+            await LoadSpell(spellId);
         }
 
         private void SyncSpell()
@@ -100,11 +100,12 @@ namespace DOLToolbox.Controls
         private void Clear()
         {
             _spell = null;
+            BindingService.ClearData(this);
         }
 
         private void button3_Click(object sender, EventArgs e)
         {
-            BindingService.ClearData(this);
+            Clear();
         }
 
         private void button4_Click(object sender, EventArgs e)

--- a/DOLToolbox/Services/ItemService.cs
+++ b/DOLToolbox/Services/ItemService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DOL.Database;
+using DOL.Database.UniqueID;
 
 namespace DOLToolbox.Services
 {
@@ -20,18 +21,20 @@ namespace DOLToolbox.Services
             return await Task.Run(() => DatabaseManager.Database.SelectAllObjects<ItemTemplate>().ToList());
         }
 
-        public void SaveItem(ItemTemplate _item)
+        public string SaveItem(ItemTemplate item)
         {
-            _item.AllowUpdate = true;
-            _item.Dirty = true;
+            item.AllowUpdate = true;
+            item.Dirty = true;
 
-            if (string.IsNullOrWhiteSpace(_item.ObjectId))
+            if (!item.IsPersisted)
             {
-                DatabaseManager.Database.AddObject(_item);
-                return;
+                DatabaseManager.Database.AddObject(item);
+                return item.ObjectId;
             }
 
-            DatabaseManager.Database.SaveObject(_item);
+            DatabaseManager.Database.SaveObject(item);
+
+            return item.ObjectId;
         }
 
 

--- a/DOLToolbox/Services/MobService.cs
+++ b/DOLToolbox/Services/MobService.cs
@@ -9,15 +9,16 @@ namespace DOLToolbox.Services
             return DatabaseManager.Database.FindObjectByKey<Mob>(mobId);
         }
 
-        public void SaveMob(Mob mob)
+        public string SaveMob(Mob mob)
         {
-            if (string.IsNullOrWhiteSpace(mob.ObjectId))
+            if (!mob.IsPersisted)
             {
                 DatabaseManager.Database.AddObject(mob);
-                return;
+                return mob.ObjectId;
             }
             
             DatabaseManager.Database.SaveObject(mob);
+            return mob.ObjectId;
         }
 
         public void DeleteMob(Mob mob)

--- a/DOLToolbox/Services/NpcTemplateService.cs
+++ b/DOLToolbox/Services/NpcTemplateService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using DOL.Database;
+using DOL.Database.UniqueID;
 
 namespace DOLToolbox.Services
 {
@@ -19,15 +20,17 @@ namespace DOLToolbox.Services
             return await Task.Run(() => DatabaseManager.Database.SelectAllObjects<DBNpcTemplate>().ToList());
         }
 
-        public void Save(DBNpcTemplate template)
+        public string Save(DBNpcTemplate template)
         {
-            if (string.IsNullOrWhiteSpace(template.ObjectId))
+            if (!template.IsPersisted)
             {
+                template.ObjectId = IDGenerator.GenerateID();
                 DatabaseManager.Database.AddObject(template);
-                return;
+                return template.ObjectId;
             }
             
             DatabaseManager.Database.SaveObject(template);
+            return template.ObjectId;
         }
 
         public void Delete(DBNpcTemplate template)

--- a/DOLToolbox/Services/SpellService.cs
+++ b/DOLToolbox/Services/SpellService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using DOL.Database;
+using DOL.Database.UniqueID;
 
 namespace DOLToolbox.Services
 {
@@ -19,15 +20,17 @@ namespace DOLToolbox.Services
             return await Task.Run(() => DatabaseManager.Database.SelectAllObjects<DBSpell>().ToList());
         }
 
-        public void Save(DBSpell spell)
+        public string Save(DBSpell spell)
         {
-            if (string.IsNullOrWhiteSpace(spell.ObjectId))
+            if (!spell.IsPersisted)
             {
+                spell.ObjectId = IDGenerator.GenerateID();
                 DatabaseManager.Database.AddObject(spell);
-                return;
+                return spell.ObjectId;
             }
 
             DatabaseManager.Database.SaveObject(spell);
+            return spell.ObjectId;
         }
 
         public int GetNextSpellId()


### PR DESCRIPTION
item, mob, npcTemplate, spell tabs will now refresh the record on save/insert rather than clearing the form. this will make it easier to add multiple similar records.